### PR TITLE
Disable removed Sky Flyer lock

### DIFF
--- a/worlds/apeescape/Client.py
+++ b/worlds/apeescape/Client.py
@@ -278,8 +278,8 @@ class ApeEscapeClient(BizHawkClient):
     def unlockLevels(self, monkeylevelCounts, gadgets):
 
         key = self.worldkeycount
-        if key > 3 and (gadgets & RAM.items["Flyer"] != RAM.items["Flyer"]):
-            key = 3
+        # if key > 3 and (gadgets & RAM.items["Flyer"] != RAM.items["Flyer"]):
+        #    key = 3
 
         current = RAM.levelStatus["Open"].to_bytes(1, byteorder="little")
         currentLock = RAM.levelStatus["Locked"].to_bytes(1, byteorder="little")


### PR DESCRIPTION
Levels beyond Gladiator Attack were briefly changed to require the Sky Flyer to access - the logic was reverted, but the client change was missed.